### PR TITLE
fix: add missing dependency '@nextui-org/theme' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fontsource/merriweather": "^5.1.1",
     "@hookform/resolvers": "^3.9.1",
     "@nextui-org/react": "^2.6.10",
+    "@nextui-org/theme": "^2.4.4",
     "@react-router/fs-routes": "^7.1.1",
     "@react-router/node": "^7.1.1",
     "@react-router/serve": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@nextui-org/react":
         specifier: ^2.6.10
         version: 2.6.10(@types/react@19.0.2)(framer-motion@11.15.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(tailwindcss@3.4.17)
+      "@nextui-org/theme":
+        specifier: ^2.4.4
+        version: 2.4.4(tailwindcss@3.4.17)
       "@react-router/fs-routes":
         specifier: ^7.1.1
         version: 7.1.1(@react-router/dev@7.1.1(@react-router/serve@7.1.1(react-router@7.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(typescript@5.7.2))(@types/node@22.10.1)(jiti@1.21.6)(react-router@7.1.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tsx@4.19.2)(typescript@5.7.2)(vite@6.0.6(@types/node@22.10.1)(jiti@1.21.6)(tsx@4.19.2)(yaml@2.6.1))(yaml@2.6.1))(typescript@5.7.2)


### PR DESCRIPTION
Login UI crashed, it was found that the necessary dependencies were missing.